### PR TITLE
chore: update to latest pnpm and add 48 hours dependency delay

### DIFF
--- a/.github/workflows/actions/install/action.yml
+++ b/.github/workflows/actions/install/action.yml
@@ -3,37 +3,18 @@ description: "PNPM & Turbo Cache"
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v4
+    - name: Cache turbo build setup
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       name: Install pnpm
       with:
         run_install: false
-
-    - name: Setup Node.js environment
-      uses: actions/setup-node@v3
-      with:
-        node-version: lts/*
-        cache: "pnpm"
-
-    - name: Get pnpm store directory
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      shell: bash
-
-    - uses: actions/cache@v3
-      name: Setup pnpm cache
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
-
-    - name: Cache turbo build setup
-      uses: actions/cache@v3
-      with:
-        path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-turbo-
 
     - name: Install dependencies
       run: pnpm install

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "ix-starter",
   "private": true,
   "scripts": {
     "build": "turbo run build",
@@ -14,6 +15,12 @@
     "turbo": "latest",
     "ix-theme-downloader": "workspace:*"
   },
-  "packageManager": "pnpm@10.14.0",
-  "name": "ix-starter"
+  "packageManager": "pnpm@10.17.0",
+  "engines": {
+    "pnpm": ">=10.x.x",
+    "node": ">=22.19.x"
+  },
+  "volta": {
+    "node": "22.19.0"
+  }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ packages:
   - "apps/*"
   - "packages/*"
   - "tools/*"
+
+minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - "@siemens/*"


### PR DESCRIPTION
Due the fact of the reason supply chain attacks we update pnpm to the latest version and uses the delayed dependency feature.